### PR TITLE
Convert static module to constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -6,7 +6,15 @@ var sendCommand = require('./lib/sendCommand');
 var stk500 = function (opts) {
   this.opts = opts || {};
   this.quiet = this.opts.quiet || false;
-  this.log = (this.quiet) ? function(){} : console.log.bind(window);
+  if(this.quiet){
+    this.log = function(){};
+  }else{
+    if(window){
+      this.log = console.log.bind(window);
+    }else{
+      this.log = console.log;
+    }
+  }
 }
 
 stk500.prototype.sync = function (stream, attempts, timeout, done) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var sendCommand = require('./lib/sendCommand');
 var stk500 = function (opts) {
   this.opts = opts || {};
   this.quiet = this.opts.quiet || false;
-  this.log = (this.quiet) ? function(){} : console.log;
+  this.log = (this.quiet) ? function(){} : console.log.bind(window);
 }
 
 stk500.prototype.sync = function (stream, attempts, timeout, done) {
@@ -55,7 +55,11 @@ stk500.prototype.verifySignature = function (stream, signature, timeout, done) {
     timeout: timeout
   };
   sendCommand(stream, opt, function (err, data) {
-		self.log('confirm signature', err, data, data.toString('hex'));
+    if(data){
+      self.log('confirm signature', err, data, data.toString('hex'));
+    }else{
+      self.log('confirm signature', err, 'no data');
+    }
     done(err, data);
   });
 };

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   "license": "MIT",
   "dependencies": {
     "async": "^0.9.0",
-    "buffer-equal": "0.0.1",
-    "sinon": "^1.12.2"
+    "buffer-equal": "0.0.1"
   },
   "devDependencies": {
     "event-stream": "^3.1.7",
     "mocha": "^2.0.1",
     "should": "^4.4.1",
     "intel-hex": "^0.1.1",
-    "serialport": "^1.4.0"
+    "serialport": "^1.4.0",
+    "sinon": "^1.12.2"
   }
 }


### PR DESCRIPTION
Hello @jacobrosenthal !

It was wonderful to catch up at IoT DevFest recently! As we briefly discussed, I'm giving AVRGirl-Arduino some TLC and one of the tasks is to propose we merge in some changes I made to this library to get it back on the mainline. These changes are mostly from a long time ago, as I've been relying on a fork of this library and pinning to it in AVRGirl-Arduino's dependencies.

The biggest change to this library I am proposing is to convert it to be used as an instance, and to allow opting out of the debug logs. There are a couple of bug fixes and improvements that were made by a community member of AVRGirl additionally.

This is a breaking change, so we'd have to bump this to a new major. I think it's worth it (at least to me!) as I think I'm the main consumer of this library and I'd love for some new upcoming improvements to be part of this main module in npm.

![bitmoji](https://render.bitstrips.com/v2/cpanel/69afa8e2-ef74-4725-adce-55ff1d3f520d-3e6ec2eb-4a75-4883-8b5f-642a34e22cfc-v1.png?transparent=1&palette=1&width=246)

