### PR TITLE
Add two dummy syncs like avrdude does

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,9 @@ stk500.prototype.bootload = function (stream, hex, opt, done) {
   }
 
   async.series([
+    // send two dummy syncs like avrdude does
+    this.sync.bind(this, stream, 3, opt.timeout),
+    this.sync.bind(this, stream, 3, opt.timeout),
     this.sync.bind(this, stream, 3, opt.timeout),
     this.verifySignature.bind(this, stream, opt.signature, opt.timeout),
     this.setOptions.bind(this, stream, parameters, opt.timeout),


### PR DESCRIPTION
When using this module with Chrome OS 74 in conjunction with `avrgirl-arduino`, `Sending 3020: receiveData timeout after 400ms` errors started to appear if multiple uploads where done sequentially.

This proposal ensures 2 dummy sync commands are always sent "... to get rid of line noise ".
https://github.com/kcuzner/avrdude/blob/master/avrdude/stk500.c#L91-L98

There might be better ways to achieve the same result, this one has more minimal churn.