### PR TITLE
use updated secure buffer methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var async = require("async");
-var bufferEqual = require('buffer-equal');
 var Statics = require('./lib/statics');
 var sendCommand = require('./lib/sendCommand');
 
@@ -50,9 +49,9 @@ stk500.prototype.verifySignature = function (stream, signature, timeout, done) {
 	this.log("verify signature");
 	var self = this;
 	match = Buffer.concat([
-    new Buffer([Statics.Resp_STK_INSYNC]),
+    Buffer.from([Statics.Resp_STK_INSYNC]),
     signature,
-    new Buffer([Statics.Resp_STK_OK])
+    Buffer.from([Statics.Resp_STK_OK])
   ]);
 
   var opt = {
@@ -170,9 +169,9 @@ stk500.prototype.loadPage = function (stream, writeBytes, timeout, done) {
 	var bytes_high = writeBytes.length >> 8;
 
 	var cmd = Buffer.concat([
-    new Buffer([Statics.Cmnd_STK_PROG_PAGE, bytes_high, bytes_low, 0x46]),
+    Buffer.from([Statics.Cmnd_STK_PROG_PAGE, bytes_high, bytes_low, 0x46]),
     writeBytes,
-    new Buffer([Statics.Sync_CRC_EOP])
+    Buffer.from([Statics.Sync_CRC_EOP])
   ]);
 
   var opt = {
@@ -302,9 +301,9 @@ stk500.prototype.verifyPage = function (stream, writeBytes, pageSize, timeout, d
 	this.log("verify page");
 	var self = this;
 	match = Buffer.concat([
-    new Buffer([Statics.Resp_STK_INSYNC]),
+    Buffer.from([Statics.Resp_STK_INSYNC]),
     writeBytes,
-    new Buffer([Statics.Resp_STK_OK])
+    Buffer.from([Statics.Resp_STK_OK])
   ]);
 
 	var size = writeBytes.length >= pageSize ? pageSize : writeBytes.length;

--- a/lib/receiveData.js
+++ b/lib/receiveData.js
@@ -5,7 +5,7 @@ var startingBytes = [
 ];
 
 module.exports = function (stream, timeout, responseLength, callback) {
-  var buffer = new Buffer(0);
+  var buffer = Buffer.alloc(0);
   var started = false;
   var timeoutId = null;
   var handleChunk = function (data) {

--- a/lib/sendCommand.js
+++ b/lib/sendCommand.js
@@ -36,7 +36,7 @@ module.exports = function (stream, opt, callback) {
         return callback(error);
       }
 
-      if (responseData && !bufferEqual(data, responseData)) {
+      if (responseData && !data.equals(responseData)) {
         error = new Error(cmd + ' response mismatch: '+data.toString('hex')+', '+responseData.toString('hex'));
         return callback(error);
       }

--- a/lib/sendCommand.js
+++ b/lib/sendCommand.js
@@ -1,4 +1,3 @@
-var bufferEqual = require('buffer-equal');
 var receiveData = require('./receiveData');
 var Statics = require('./statics');
 
@@ -23,7 +22,7 @@ module.exports = function (stream, opt, callback) {
   }
   var cmd = opt.cmd;
   if (cmd instanceof Array) {
-    cmd = new Buffer(cmd.concat(Statics.Sync_CRC_EOP));
+    cmd = Buffer.from(cmd.concat(Statics.Sync_CRC_EOP));
   }
 
   stream.write(cmd, function (err) {

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -20,5 +20,5 @@ module.exports = {
   Cmnd_STK_READ_PAGE: 0x74,
 
 
-  OK_RESPONSE: new Buffer([Resp_STK_INSYNC, Resp_STK_OK])
+  OK_RESPONSE: Buffer.from([Resp_STK_INSYNC, Resp_STK_OK])
 };

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "author": "Jacob Rosenthal",
   "license": "MIT",
   "dependencies": {
-    "async": "^0.9.0",
-    "buffer-equal": "0.0.1"
+    "async": "^0.9.0"
   },
   "devDependencies": {
     "event-stream": "^3.1.7",

--- a/test/receiveData.js
+++ b/test/receiveData.js
@@ -1,7 +1,6 @@
 var Statics = require('../lib/statics');
 var receiveData = require('../lib/receiveData');
 var es = require('event-stream');
-var bufferEqual = require('buffer-equal');
 
 describe('receiveData', function () {
   beforeEach(function () {
@@ -17,7 +16,7 @@ describe('receiveData', function () {
         return done(err);
       }
       Should.not.exist(err);
-      var matched = bufferEqual(data, inputBuffer);
+      var matched = data.equals(inputBuffer);
       Should.exist(matched);
       matched.should.equal(true);
       done();
@@ -44,7 +43,7 @@ describe('receiveData', function () {
         return done(err);
       }
       Should.not.exist(err);
-      var matched = bufferEqual(data, inputBuffer);
+      var matched = data.equals(inputBuffer);
       Should.exist(matched);
       matched.should.equal(true);
       done();

--- a/test/sendCommand.js
+++ b/test/sendCommand.js
@@ -2,7 +2,6 @@ var sinon = require("sinon");
 var Statics = require('../lib/statics');
 var sendCommand = require('../lib/sendCommand');
 var es = require('event-stream');
-var bufferEqual = require('buffer-equal');
 
 var EventEmitter = require('events').EventEmitter;
 
@@ -32,14 +31,14 @@ describe('sendCommands', function () {
 
   it('should write a buffer command', function (done) {
     var writeSpy = sandbox.spy(hardware, 'write');
-    var cmd = new Buffer([Statics.Cmnd_STK_GET_SYNC, Statics.Sync_CRC_EOP]);
+    var cmd = Buffer.from([Statics.Cmnd_STK_GET_SYNC, Statics.Sync_CRC_EOP]);
     var opt = {
       cmd: cmd,
       responseData: Statics.OK_RESPONSE,
       timeout: 10
     };
     sendCommand(hardware, opt, function (err, data) {
-      var matched = bufferEqual(writeSpy.args[0][0], cmd);
+      var matched = writeSpy.args[0][0].equals(cmd);
       Should.exist(matched);
       matched.should.equal(true);
       done();
@@ -59,7 +58,7 @@ describe('sendCommands', function () {
       timeout: 10
     };
     sendCommand(hardware, opt, function (err, data) {
-      var matched = bufferEqual(writeSpy.args[0][0], new Buffer([Statics.Cmnd_STK_GET_SYNC, Statics.Sync_CRC_EOP]));
+      var matched = writeSpy.args[0][0].equals(Buffer.from([Statics.Cmnd_STK_GET_SYNC, Statics.Sync_CRC_EOP]));
       Should.exist(matched);
       matched.should.equal(true);
       done();
@@ -103,7 +102,7 @@ describe('sendCommands', function () {
         return done(err);
       }
       Should.not.exist(err);
-      var matched = bufferEqual(data, Statics.OK_RESPONSE);
+      var matched = data.equals(Statics.OK_RESPONSE);
       Should.exist(matched);
       matched.should.equal(true);
       done();
@@ -128,7 +127,7 @@ describe('sendCommands', function () {
         return done(err);
       }
       Should.not.exist(err);
-      var matched = bufferEqual(data, Statics.OK_RESPONSE);
+      var matched = data.equals(Statics.OK_RESPONSE);
       Should.exist(matched);
       matched.should.equal(true);
       done();


### PR DESCRIPTION
👋

This PR does it what it says on the tin. I updated all of the new Buffer() calls to the more modern and safe ones. It removes deprecation warnings in the terminal output of any project that consumes this library.

Thanks for your time! 🙇 🕙