### PR TITLE
prevent thrown error on undeclared window var

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var stk500 = function (opts) {
   if(this.quiet){
     this.log = function(){};
   }else{
-    if(window){
+    if(typeof window === 'object'){
       this.log = console.log.bind(window);
     }else{
       this.log = console.log;


### PR DESCRIPTION
👋 😄 

When this branch is entered upon quiet mode being false, there is a reference error thrown because of the undeclared `window` variable. This fixes the code so that the variable is checked correctly in strict mode.