### PR TITLE
Fix race condition on sendCommand.js

### DIFF
--- a/lib/receiveData.js
+++ b/lib/receiveData.js
@@ -35,7 +35,7 @@ module.exports = function (stream, timeout, responseLength, callback) {
     }
     // VALIDATE TERMINAL BYTE?
     stream.removeListener('data', handleChunk);
-    callback(err, buffer);
+    return callback(err, buffer);
   };
   if (timeout && timeout > 0) {
     timeoutId = setTimeout(function () {
@@ -44,4 +44,5 @@ module.exports = function (stream, timeout, responseLength, callback) {
     }, timeout);
   }
   stream.on('data', handleChunk);
+  return finished;
 };

--- a/lib/sendCommand.js
+++ b/lib/sendCommand.js
@@ -11,6 +11,13 @@ module.exports = function (stream, opt, callback) {
   var responseLength = 0;
   var error;
 
+  //If we have an error trying to send data, blocks the callback frum running again
+  //even if the receivedata receives data
+  var wrappedCallback = function(err, d){
+    callback(err, d);
+    wrappedCallback = function(){};
+  }
+
   if (opt.responseData && opt.responseData.length > 0) {
     responseData = opt.responseData;
   }
@@ -25,22 +32,23 @@ module.exports = function (stream, opt, callback) {
     cmd = Buffer.from(cmd.concat(Statics.Sync_CRC_EOP));
   }
 
+  receiveData(stream, timeout, responseLength, function (err, data) {
+    if (err) {
+      error = new Error('Sending ' + cmd.toString('hex') + ': ' + err.message);
+      return wrappedCallback(error);
+    }
+
+    if (responseData && !data.equals(responseData)) {
+      error = new Error(cmd + ' response mismatch: '+data.toString('hex')+', '+responseData.toString('hex'));
+      return wrappedCallback(error);
+    }
+    wrappedCallback(null, data);
+  });
+
   stream.write(cmd, function (err) {
     if (err) {
       error = new Error('Sending ' + cmd.toString('hex') + ': ' + err.message);
-      return callback(error);
+      return wrappedCallback(error);
     }
-    receiveData(stream, timeout, responseLength, function (err, data) {
-      if (err) {
-        error = new Error('Sending ' + cmd.toString('hex') + ': ' + err.message);
-        return callback(error);
-      }
-
-      if (responseData && !data.equals(responseData)) {
-        error = new Error(cmd + ' response mismatch: '+data.toString('hex')+', '+responseData.toString('hex'));
-        return callback(error);
-      }
-      callback(null, data);
-    });
   });
 };

--- a/lib/sendCommand.js
+++ b/lib/sendCommand.js
@@ -11,13 +11,6 @@ module.exports = function (stream, opt, callback) {
   var responseLength = 0;
   var error;
 
-  //If we have an error trying to send data, blocks the callback frum running again
-  //even if the receivedata receives data
-  var wrappedCallback = function(err, d){
-    callback(err, d);
-    wrappedCallback = function(){};
-  }
-
   if (opt.responseData && opt.responseData.length > 0) {
     responseData = opt.responseData;
   }
@@ -32,23 +25,23 @@ module.exports = function (stream, opt, callback) {
     cmd = Buffer.from(cmd.concat(Statics.Sync_CRC_EOP));
   }
 
-  receiveData(stream, timeout, responseLength, function (err, data) {
+  var finish = receiveData(stream, timeout, responseLength, function (err, data) {
     if (err) {
       error = new Error('Sending ' + cmd.toString('hex') + ': ' + err.message);
-      return wrappedCallback(error);
+      return callback(error);
     }
 
     if (responseData && !data.equals(responseData)) {
       error = new Error(cmd + ' response mismatch: '+data.toString('hex')+', '+responseData.toString('hex'));
-      return wrappedCallback(error);
+      return callback(error);
     }
-    wrappedCallback(null, data);
+    callback(null, data);
   });
 
   stream.write(cmd, function (err) {
     if (err) {
       error = new Error('Sending ' + cmd.toString('hex') + ': ' + err.message);
-      return wrappedCallback(error);
+      return finish(error);
     }
   });
 };


### PR DESCRIPTION
I had a real-world problem with avrgirl-arduino, which depends on this library, it turns out that, this library subscribes to receive data only after sending data to the board, on slower computers, this makes the board sends the response before the library starts listening to data, which makes the library lose the transmission and trigger a timeout error.
The change passed on the unit test, and I've successfully uploaded  the blink sketch to an Arduino Uno