### PR TITLE
fixbug: crash when data is null or undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,11 @@ stk500.prototype.verifyPage = function (stream, writeBytes, pageSize, timeout, d
     timeout: timeout
   };
   sendCommand(stream, opt, function (err, data) {
-		self.log('confirm page', err, data, data.toString('hex'));
+    if(data){
+      self.log('confirm page', err, data, data.toString('hex'));
+    }else{
+      self.log('confirm page', err, 'no data');
+    }
     done(err, data);
   }); 
 };


### PR DESCRIPTION
This is crash log：
···
xxx\node_modules\stk500\index.js:322
                self.log('confirm page', err, data, data.toString('hex'));  
                                                         ^

TypeError: Cannot read properties of undefined (reading 'toString')
···
check the data if undefined  will fix it
